### PR TITLE
Walls are now stored by reference and not by value as before. As a re…

### DIFF
--- a/src/Camera.cs
+++ b/src/Camera.cs
@@ -1,6 +1,6 @@
 ﻿#pragma warning disable IDE1006
 #define DEVELOPMENT
-#undef CPP
+#define CPP
 #undef PARALLEL
 
 using GLTech2.Properties;

--- a/src/Header.h
+++ b/src/Header.h
@@ -45,10 +45,10 @@ struct Sprite_
 
 struct Map_
 {
-	Sprite_* sprities;
+	Sprite_** sprities;
 	int sprite_count;
 	int sprite_max;
-	Wall_* walls;
+	Wall_** walls;
 	int wall_count;
 	int wall_max;
 };

--- a/src/Map.cs
+++ b/src/Map.cs
@@ -13,10 +13,10 @@ namespace GLTech2
     [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct Map_ : IDisposable
     {
-        internal Sprite_* sprities;
+        internal Sprite_** sprities;
         internal int sprite_count;
         internal int sprite_max;
-        internal Wall_* walls;
+        internal Wall_** walls;
         internal int wall_count;
         internal int wall_max;
 
@@ -24,8 +24,8 @@ namespace GLTech2
         internal static Map_* Alloc(int maxWalls, int masSprities)
         {
             Map_* result = (Map_*)Marshal.AllocHGlobal(sizeof(Map_));
-            result->sprities = (Sprite_*)Marshal.AllocHGlobal(masSprities * sizeof(void*)); // Not implemented yet
-            result->walls = (Wall_*)Marshal.AllocHGlobal(maxWalls * sizeof(Wall_));
+            result->sprities = (Sprite_**)Marshal.AllocHGlobal(masSprities * sizeof(Sprite_*)); // Not implemented yet
+            result->walls = (Wall_**)Marshal.AllocHGlobal(maxWalls * sizeof(Wall_*));
             result->sprite_count = 0;
             result->sprite_max = masSprities;
             result->wall_count = 0;
@@ -41,7 +41,7 @@ namespace GLTech2
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void Add(Wall_* wall) => walls[wall_count++] = *wall;
+        internal void Add(Wall_* wall) => walls[wall_count++] = wall;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void Add(void* sprite) => throw new NotImplementedException();

--- a/src/Methods.cpp
+++ b/src/Methods.cpp
@@ -42,19 +42,19 @@ Wall_* Ray::NearestWall(Map_* map, float& nearest_dist, float& nearest_ratio)
     nearest_dist = FLT_MAX;
     nearest_ratio = FLT_MAX;
     int wallcount = map->wall_count;
-    Wall_* cur = map->walls;
+    Wall_** cur = map->walls;
     Wall_* nearest = NULL;
 
     for (int i = 0; i < wallcount; i++)
     {
         if (cur == NULL) break;
         float cur_dist, cur_ratio;
-        GetCollisionData(cur, cur_dist, cur_ratio);
+        GetCollisionData(*cur, cur_dist, cur_ratio);
         if (cur_dist < nearest_dist)
         {
             nearest_ratio = cur_ratio;
             nearest_dist = cur_dist;
-            nearest = cur;
+            nearest = *cur;
         }
         cur++;
     }

--- a/src/Ray.cs
+++ b/src/Ray.cs
@@ -58,18 +58,18 @@ namespace GLTech2
             nearest_dist = float.PositiveInfinity;
             nearest_ratio = float.PositiveInfinity;
             int wallcount = map->wall_count;
-            Wall_* cur = map->walls;
+            Wall_** cur = map->walls;
             Wall_* nearest = null;
 
             for (int i = 0; i < wallcount; i++)
             {
                 if (cur == null) break;
-                GetCollisionData(cur, out float cur_dist, out float cur_ratio);
+                GetCollisionData(*cur, out float cur_dist, out float cur_ratio);
                 if (cur_dist < nearest_dist)
                 {
                     nearest_ratio = cur_ratio;
                     nearest_dist = cur_dist;
-                    nearest = cur;
+                    nearest = *cur;
                 }
                 cur++;
             }

--- a/src/Wall.cs
+++ b/src/Wall.cs
@@ -318,11 +318,6 @@ namespace GLTech2
         {
             Marshal.FreeHGlobal((IntPtr) unmanaged);
         }
-
-        ~Wall()
-        {
-            this.Dispose();
-        }
         #endregion
     }
 }

--- a/test/GL Tech 2 Example/MainWindow.cs
+++ b/test/GL Tech 2 Example/MainWindow.cs
@@ -1,8 +1,6 @@
 ﻿using Game.Properties;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using GLTech2;


### PR DESCRIPTION
…sult, now you can change properties of a wall after binding it to a map and they'll take effect.

Consequently, walls are not automatically collected by the GC. However, the user doesn't need to dispose it manually anymore, since it's dispose method is called by Map.Dispose().
C# Frametime: 26.34 +- 4.23ms
C++ Frametime: 18.52 +- 2.61ms